### PR TITLE
tvm_to_python: fix invalid -inf codegen for ONNX Clip with no lower bound

### DIFF
--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1184,8 +1184,12 @@ def populate_clip_transpose_args(graph, nid, compiler_cfg):
     min = float(node["attrs"]["a_min"][0][0])
     max = float(node["attrs"]["a_max"][0][0])
 
-    if min == float("inf"):
-        min = "float('inf')"
+    # TVM emits a_min == -inf when the ONNX Clip has no lower bound (e.g. an
+    # omitted `min` on opset <= 10, or a -inf min constant). Emit a valid Python
+    # literal for it; a bare `-inf` in the generated code raises NameError. This
+    # mirrors the a_max == +inf handling below.
+    if min == float("-inf"):
+        min = "float('-inf')"
 
     if max == float("inf"):
         max = "float('inf')"

--- a/forge/test/mlir/test_ops_onnx.py
+++ b/forge/test/mlir/test_ops_onnx.py
@@ -92,6 +92,51 @@ def test_arithmetic():
 
 
 @pytest.mark.push
+def test_clip_no_min():
+    # ONNX Clip with only an upper bound: the omitted `min` lowers to a_min == -inf
+    # in the TVM frontend. Exercises the -inf codegen path in
+    # populate_clip_transpose_args (a bare `-inf` literal would raise NameError).
+    input_shape = [2, 32, 32]
+
+    input = helper.make_tensor_value_info("input", TensorProto.FLOAT, input_shape)
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, input_shape)
+
+    min_val = np.array(-np.inf, dtype=np.float32)
+    max_val = np.array(6.0, dtype=np.float32)
+
+    initializer = [
+        numpy_helper.from_array(min_val, "min"),
+        numpy_helper.from_array(max_val, "max"),
+    ]
+
+    clip_node = helper.make_node(
+        "Clip",
+        inputs=["input", "min", "max"],
+        outputs=["output"],
+    )
+
+    graph = helper.make_graph(
+        nodes=[clip_node],
+        name="ClipGraph",
+        inputs=[input],
+        outputs=[output],
+        initializer=initializer,
+    )
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="ClipModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand(input_shape) * 10.0]
+
+    onnx_module = forge.OnnxModule("clip_no_min", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
 def test_matmul():
     input_A = helper.make_tensor_value_info("input_A", TensorProto.FLOAT, [32, 64])
     input_B = helper.make_tensor_value_info("input_B", TensorProto.FLOAT, [64, 32])


### PR DESCRIPTION
### Ticket
N/A — self-contained frontend bug fix (found while auditing ONNX op-coverage in the `tvm_to_python` frontend).

### Problem description
`populate_clip_transpose_args` builds the `min`/`max` kwargs for `forge.op.Clip`
from the relay `clip` op's `a_min`/`a_max` attributes.

When an ONNX `Clip` has **no lower bound** — an omitted `min` on opset ≤ 10, or a
`-inf` min constant — TVM's ONNX frontend lowers it to `a_min == -inf`
(`Clip._impl_v1` sets `attr["min"] = -np.inf`). The existing guard only checks
the **positive** infinity:

```python
if min == float("inf"):        # never true for a min bound
    min = "float('inf')"
```

So `-inf` falls through and is emitted verbatim into the generated module as the
bare literal `min=-inf`, which is **not valid Python** and raises
`NameError: name 'inf' is not defined` when the generated forge module is
executed. The `a_max == +inf` case is already handled correctly one line below;
the `min` side was simply guarding the wrong sign.

### What's changed
- Guard the lower bound against `-inf` and emit `float('-inf')`, mirroring the
  existing `a_max == +inf` handling. Minimal, one-line-of-logic fix; the finite
  and `+inf` paths are untouched.
- Add `test_clip_no_min` to `forge/test/mlir/test_ops_onnx.py`: an ONNX `Clip`
  with only an upper bound, which exercises the `a_min == -inf` codegen path.

### Checklist
- [x] New/Existing tests provide coverage for changes

---
Note: I do not have Tenstorrent hardware locally, so the hardware `verify()` in
the added test was not run on-device from my side. The fix itself is a codegen
correctness change verified by inspection against the TVM source and by
reproducing the invalid/valid generated literal; the added ONNX model was
validated with `onnx.checker`.
