### PR TITLE
Remove legacy MLIRConfig options and fix perf benchmark

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -170,12 +170,6 @@ PYBIND11_MODULE(_C, m)
 
     py::register_exception<UnsupportedHWOpsError>(m, "UnsupportedHWOpsError");
 
-    py::enum_<tt::passes::MemoryLayoutAnalysisPolicy>(m, "MemoryLayoutAnalysisPolicy")
-        .value("DFSharding", tt::passes::MemoryLayoutAnalysisPolicy::DFSharding)
-        .value("GreedyL1Interleaved", tt::passes::MemoryLayoutAnalysisPolicy::GreedyL1Interleaved)
-        .value("BFInterleaved", tt::passes::MemoryLayoutAnalysisPolicy::BFInterleaved)
-        .export_values();
-
     py::class_<tt::passes::MLIRConfig>(m, "MLIRConfig")
         .def(py::init<>())
         .def(
@@ -193,20 +187,6 @@ PYBIND11_MODULE(_C, m)
         .def(
             "set_enable_memory_layout_analysis",
             [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_memory_layout_analysis(enable); },
-            py::arg("enable"))
-        .def(
-            "set_memory_layout_analysis_policy",
-            [](tt::passes::MLIRConfig &self, tt::passes::MemoryLayoutAnalysisPolicy policy)
-            { return self.set_memory_layout_analysis_policy(policy); },
-            py::arg("policy"))
-        .def(
-            "set_enable_l1_interleaved_fallback_analysis",
-            [](tt::passes::MLIRConfig &self, bool enable)
-            { return self.set_enable_l1_interleaved_fallback_analysis(enable); },
-            py::arg("enable"))
-        .def(
-            "set_enable_memreconfig",
-            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_memreconfig(enable); },
             py::arg("enable"))
         .def(
             "set_max_legal_layouts",

--- a/forge/csrc/passes/mlir_config.cpp
+++ b/forge/csrc/passes/mlir_config.cpp
@@ -11,13 +11,6 @@
 namespace tt::passes
 {
 
-void to_json(nlohmann::json& j, MemoryLayoutAnalysisPolicy p) { j = to_pipeline_string(p); }
-
-void from_json(const nlohmann::json& j, MemoryLayoutAnalysisPolicy& p)
-{
-    p = memory_layout_policy_from_string(j.get<std::string>());
-}
-
 void to_json(::nlohmann::json& j, const MLIRConfig& p)
 {
     const auto fidelity_val = [&]() -> nlohmann::json
@@ -41,9 +34,6 @@ void to_json(::nlohmann::json& j, const MLIRConfig& p)
                        {"enable_optimizer", p.enable_optimizer},
                        {"enable_memory_layout_analysis", p.enable_memory_layout_analysis},
                        // Memory layout options
-                       {"memory_layout_analysis_policy", p.memory_layout_analysis_policy},
-                       {"enable_l1_interleaved_fallback_analysis", p.enable_l1_interleaved_fallback_analysis},
-                       {"enable_memreconfig", p.enable_memreconfig},
                        {"max_legal_layouts", p.max_legal_layouts},
                        {"enable_row_major", p.enable_row_major},
                        // Compute kernel configuration
@@ -87,9 +77,6 @@ void from_json(const ::nlohmann::json& j, MLIRConfig& p)
     j.at("enable_optimizer").get_to(p.enable_optimizer);
     j.at("enable_memory_layout_analysis").get_to(p.enable_memory_layout_analysis);
     // Memory layout options
-    j.at("memory_layout_analysis_policy").get_to(p.memory_layout_analysis_policy);
-    j.at("enable_l1_interleaved_fallback_analysis").get_to(p.enable_l1_interleaved_fallback_analysis);
-    j.at("enable_memreconfig").get_to(p.enable_memreconfig);
     j.at("max_legal_layouts").get_to(p.max_legal_layouts);
     j.at("enable_row_major").get_to(p.enable_row_major);
     // Compute kernel configuration
@@ -157,13 +144,6 @@ std::string config_to_pipeline_options(const std::optional<MLIRConfig>& mlir_con
     // -----------------------------------------------------------------------
     // Memory layout options
     // -----------------------------------------------------------------------
-    if (mlir_config->memory_layout_analysis_policy.has_value())
-        options << " memory-layout-analysis-policy=" << to_pipeline_string(*mlir_config->memory_layout_analysis_policy);
-    if (mlir_config->enable_l1_interleaved_fallback_analysis.has_value())
-        options << " l1-interleaved-fallback-analysis-enabled="
-                << *mlir_config->enable_l1_interleaved_fallback_analysis;
-    if (mlir_config->enable_memreconfig.has_value())
-        options << " memreconfig-enabled=" << *mlir_config->enable_memreconfig;
     if (mlir_config->max_legal_layouts.has_value())
         options << " max-legal-layouts=" << *mlir_config->max_legal_layouts;
     if (mlir_config->enable_row_major.has_value())

--- a/forge/csrc/passes/mlir_config.hpp
+++ b/forge/csrc/passes/mlir_config.hpp
@@ -14,65 +14,6 @@
 namespace tt::passes
 {
 
-// ============================================================================
-// MemoryLayoutAnalysisPolicy
-//
-// Maps to the `memory-layout-analysis-policy` option of
-// TTIRToTTNNDevicePipelineOptions (TTNNPipelines.h).
-//
-// Selects the search strategy used by the sharding analysis sub-pass of the
-// TTNNOptimizer when it searches for the best tensor memory layout across the
-// full compute graph.  The option only takes effect when both
-//   enable_optimizer = true
-//   enable_memory_layout_analysis = true
-// are set (or optimization_level >= 2).
-//
-// Pipeline option: memory-layout-analysis-policy   default: DFSharding
-// ============================================================================
-enum class MemoryLayoutAnalysisPolicy
-{
-    /// Depth-first data-flow driven sharding (pipeline default).
-    /// Propagates sharding decisions top-to-bottom through the dataflow graph.
-    DFSharding,
-
-    /// Greedy search that first promotes tensors to L1-interleaved layouts
-    /// before attempting block/height/width sharding.
-    GreedyL1Interleaved,
-
-    /// Breadth-first interleaved strategy.  Analyses all ops at a given depth
-    /// before moving deeper, favouring interleaved layouts throughout.
-    BFInterleaved,
-};
-
-/// Returns the pipeline option string for the given MemoryLayoutAnalysisPolicy.
-/// Throws std::invalid_argument for unknown values.
-inline std::string to_pipeline_string(MemoryLayoutAnalysisPolicy p)
-{
-    switch (p)
-    {
-        case MemoryLayoutAnalysisPolicy::DFSharding: return "DFSharding";
-        case MemoryLayoutAnalysisPolicy::GreedyL1Interleaved: return "GreedyL1Interleaved";
-        case MemoryLayoutAnalysisPolicy::BFInterleaved: return "BFInterleaved";
-    }
-    throw std::invalid_argument("Unknown MemoryLayoutAnalysisPolicy value");
-}
-
-/// Parses a pipeline option string back into a MemoryLayoutAnalysisPolicy.
-/// Throws std::invalid_argument for unknown strings.
-inline MemoryLayoutAnalysisPolicy memory_layout_policy_from_string(const std::string& s)
-{
-    if (s == "DFSharding")
-        return MemoryLayoutAnalysisPolicy::DFSharding;
-    if (s == "GreedyL1Interleaved")
-        return MemoryLayoutAnalysisPolicy::GreedyL1Interleaved;
-    if (s == "BFInterleaved")
-        return MemoryLayoutAnalysisPolicy::BFInterleaved;
-    throw std::invalid_argument("Unknown MemoryLayoutAnalysisPolicy string: " + s);
-}
-
-void to_json(nlohmann::json& j, MemoryLayoutAnalysisPolicy p);
-void from_json(const nlohmann::json& j, MemoryLayoutAnalysisPolicy& p);
-
 /// Converts tt::MathFidelity to the MLIR pipeline option string.
 /// MathFidelity::Invalid maps to "undefined" (backend-selected fidelity).
 inline std::string to_pipeline_string(tt::MathFidelity f)
@@ -186,23 +127,6 @@ struct MLIRConfig
     // -------------------------------------------------------------------------
     // Memory layout options
     // -------------------------------------------------------------------------
-
-    /// Pipeline option: memory-layout-analysis-policy   default: DFSharding
-    /// Selects the sharding search strategy used by the memory layout analysis
-    /// pass.
-    std::optional<MemoryLayoutAnalysisPolicy> memory_layout_analysis_policy = std::nullopt;
-
-    /// Pipeline option: l1-interleaved-fallback-analysis-enabled   default: false
-    /// Lightweight pass that promotes DRAM-interleaved tensors to L1-interleaved
-    /// when sufficient on-chip SRAM is available.  Works independently of the
-    /// full sharding analysis (enable_memory_layout_analysis not required).
-    std::optional<bool> enable_l1_interleaved_fallback_analysis = std::nullopt;
-
-    /// Pipeline option: memreconfig-enabled   default: true
-    /// Inserts ToLayout ops between operations whose output/input memory
-    /// layouts are incompatible.  Disable only for debugging — may produce
-    /// incorrect results when off.
-    std::optional<bool> enable_memreconfig = std::nullopt;
 
     /// Pipeline option: max-legal-layouts   default: 8
     /// Maximum number of sharded layout candidates the optimizer generates and
@@ -406,22 +330,6 @@ struct MLIRConfig
     }
 
     // Memory layout options
-    MLIRConfig& set_memory_layout_analysis_policy(MemoryLayoutAnalysisPolicy p)
-    {
-        memory_layout_analysis_policy = p;
-        return *this;
-    }
-    MLIRConfig& set_enable_l1_interleaved_fallback_analysis(bool v)
-    {
-        enable_l1_interleaved_fallback_analysis = v;
-        return *this;
-    }
-    MLIRConfig& set_enable_memreconfig(bool v)
-    {
-        enable_memreconfig = v;
-        return *this;
-    }
-
     MLIRConfig& set_max_legal_layouts(int64_t max)
     {
         if (max <= 0)

--- a/forge/test/benchmark/benchmarks/vision_benchmark.py
+++ b/forge/test/benchmark/benchmarks/vision_benchmark.py
@@ -48,7 +48,6 @@ def get_compiler_cfg(
         .set_enable_consteval(True)
         .set_optimization_level(optimization_level)
         .set_enable_trace(trace_enabled)
-        .set_enable_l1_interleaved_fallback_analysis(True)
         .set_compute_cfg_math_fidelity(forge._C.MathFidelity.HiFi2)
         .set_enable_remove_dead_values(True)
         .set_max_legal_layouts(8)

--- a/forge/test/models/onnx/vision/detr/test_detr.py
+++ b/forge/test/models/onnx/vision/detr/test_detr.py
@@ -79,7 +79,6 @@ def test_detr_segmentation_onnx(variant, forge_tmp_path):
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["facebook/detr-resnet-50"])
 def test_detr_onnx_torchhub(variant, forge_tmp_path):
     # Record Forge Property


### PR DESCRIPTION


## Summary

- Remove three legacy MLIR pipeline options (`memory-layout-analysis-policy`, `l1-interleaved-fallback-analysis-enabled`, `memreconfig-enabled`) from tt-forge-onnx that were deleted in [tt-mlir PR #9086](https://github.com/tenstorrent/tt-mlir/pull/9086)
- Fix `test_resnet50[ResNet50_HuggingFace]` benchmark failure caused by passing the now-deleted `l1-interleaved-fallback-analysis-enabled` option to the MLIR pass manager
- Remove `@pytest.mark.xfail` from `test_detr_onnx_torchhub[facebook/detr-resnet-50]` — test is passing in the nightly pipeline


## Details

### Why these options were removed upstream

tt-mlir PR #9086 deleted the entire legacy chain-based `TTNNOptimizer` path — `L1InterleavedFallbackAnalysis`, `MemReconfig`, the `MemoryLayoutAnalysis` policy dispatcher, and all three policies (DFSharding / GreedyL1Interleaved / BFInterleaved). These were dead code: at every optimization level the pipeline had already resolved to the greedy optimizer (`GreedyMemoryLayoutPropagation` + `GreedyL1SpillManagement`), which supersedes them. The three pipeline options controlling that dead path were removed along with it.

### What broke and why

The `vision_benchmark.py` benchmark was still calling `.set_enable_l1_interleaved_fallback_analysis(True)` in `get_compiler_cfg`. After the tt-mlir uplift the MLIR pass manager no longer recognised the option string, causing every benchmark compile to fail immediately:

```
<Pass-Options-Parser>: no such option l1-interleaved-fallback-analysis-enabled
RuntimeError: Failed to add the pipeline to the pass manager!
```

### What was cleaned up in tt-forge-onnx

- **`mlir_config.hpp`** — removed `MemoryLayoutAnalysisPolicy` enum and its `to_pipeline_string` / `from_string` helpers; removed fields `memory_layout_analysis_policy`, `enable_l1_interleaved_fallback_analysis`, `enable_memreconfig` and their setters
- **`mlir_config.cpp`** — removed JSON serialization (`to_json` / `from_json`) and pipeline-string emission for all three options
- **`forge_bindings.cpp`** — removed the pybind `MemoryLayoutAnalysisPolicy` enum binding and the three method bindings (`set_memory_layout_analysis_policy`, `set_enable_l1_interleaved_fallback_analysis`, `set_enable_memreconfig`)
- **`vision_benchmark.py`** — dropped the `.set_enable_l1_interleaved_fallback_analysis(True)` call that was crashing the benchmark

### xfail removal

`test_detr_onnx_torchhub[facebook/detr-resnet-50]` has been passing consistently in the nightly pipeline, so the `@pytest.mark.xfail` marker has been removed.
