### PR TITLE
Drop stale strict-xfail marks that now XPASS after the tt-mlir metal uplift

### DIFF
--- a/forge/test/mlir/operators/eltwise_binary/test_eltwise_binary.py
+++ b/forge/test/mlir/operators/eltwise_binary/test_eltwise_binary.py
@@ -481,9 +481,7 @@ def test_multiply(shape):
     "shape",
     [
         ((1, 32, 32), (1, 32, 32)),  # Same shapes
-        pytest.param(
-            ((32, 32, 1), (1,)), marks=pytest.mark.xfail(reason="Bad accuracy for backward")
-        ),  # Broadcasting scalar
+        ((32, 32, 1), (1,)),  # Broadcasting scalar
         ((32, 32), (1, 32, 32)),  # Broadcasting different ranks
         ((1, 1, 32), (1, 32, 1)),  # Broadcasting different dimensions
     ],

--- a/forge/test/mlir/operators/reduce/test_reduce.py
+++ b/forge/test/mlir/operators/reduce/test_reduce.py
@@ -14,27 +14,10 @@ from forge.verify.verify import verify
     "input_shape, dim, keepdim",
     [
         # 1D
-        pytest.param(
-            (64,), 0, True, marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs")
-        ),
-        pytest.param(
-            (64,),
-            -1,
-            True,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (64,),
-            0,
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (64,),
-            -1,
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
+        ((64,), 0, True),
+        ((64,), -1, True),
+        ((64,), 0, False),
+        ((64,), -1, False),
         # 2D - single dim
         ((32, 64), 0, True),
         ((32, 64), 0, False),
@@ -45,18 +28,8 @@ from forge.verify.verify import verify
         ((32, 64), -2, True),
         ((32, 64), -2, False),
         # 2D - multi dim
-        pytest.param(
-            (32, 64),
-            [0, 1],
-            True,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (32, 64),
-            [0, 1],
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
+        ((32, 64), [0, 1], True),
+        ((32, 64), [0, 1], False),
         # 3D - single dim
         ((4, 32, 64), 0, True),
         ((4, 32, 64), 0, False),
@@ -77,18 +50,8 @@ from forge.verify.verify import verify
         ((4, 32, 64), [0, 2], False),
         ((4, 32, 64), [1, 2], True),
         ((4, 32, 64), [1, 2], False),
-        pytest.param(
-            (4, 32, 64),
-            [0, 1, 2],
-            True,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (4, 32, 64),
-            [0, 1, 2],
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
+        ((4, 32, 64), [0, 1, 2], True),
+        ((4, 32, 64), [0, 1, 2], False),
         # 4D - single dim
         ((1, 4, 32, 64), 0, True),
         ((1, 4, 32, 64), 0, False),
@@ -126,31 +89,11 @@ from forge.verify.verify import verify
         ((1, 4, 32, 64), [0, 1, 3], False),
         ((1, 4, 32, 64), [0, 2, 3], True),
         ((1, 4, 32, 64), [0, 2, 3], False),
-        pytest.param(
-            (1, 4, 32, 64),
-            [1, 2, 3],
-            True,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (1, 4, 32, 64),
-            [1, 2, 3],
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
+        ((1, 4, 32, 64), [1, 2, 3], True),
+        ((1, 4, 32, 64), [1, 2, 3], False),
         # 4D - all dims
-        pytest.param(
-            (1, 4, 32, 64),
-            [0, 1, 2, 3],
-            True,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (1, 4, 32, 64),
-            [0, 1, 2, 3],
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
+        ((1, 4, 32, 64), [0, 1, 2, 3], True),
+        ((1, 4, 32, 64), [0, 1, 2, 3], False),
     ],
 )
 @pytest.mark.push
@@ -208,18 +151,8 @@ def test_reduce_sum(input_shape, dim, keepdim):
         ((4, 32, 64), [0, 2], False),
         ((4, 32, 64), [1, 2], True),
         ((4, 32, 64), [1, 2], False),
-        pytest.param(
-            (4, 32, 64),
-            [0, 1, 2],
-            True,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (4, 32, 64),
-            [0, 1, 2],
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
+        ((4, 32, 64), [0, 1, 2], True),
+        ((4, 32, 64), [0, 1, 2], False),
         # 4D - single dim
         ((1, 4, 32, 64), 0, True),
         ((1, 4, 32, 64), 0, False),
@@ -257,31 +190,11 @@ def test_reduce_sum(input_shape, dim, keepdim):
         ((1, 4, 32, 64), [0, 1, 3], False),
         ((1, 4, 32, 64), [0, 2, 3], True),
         ((1, 4, 32, 64), [0, 2, 3], False),
-        pytest.param(
-            (1, 4, 32, 64),
-            [1, 2, 3],
-            True,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (1, 4, 32, 64),
-            [1, 2, 3],
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
+        ((1, 4, 32, 64), [1, 2, 3], True),
+        ((1, 4, 32, 64), [1, 2, 3], False),
         # 4D - all dims
-        pytest.param(
-            (1, 4, 32, 64),
-            [0, 1, 2, 3],
-            True,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
-        pytest.param(
-            (1, 4, 32, 64),
-            [0, 1, 2, 3],
-            False,
-            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
-        ),
+        ((1, 4, 32, 64), [0, 1, 2, 3], True),
+        ((1, 4, 32, 64), [0, 1, 2, 3], False),
     ],
 )
 @pytest.mark.push


### PR DESCRIPTION
Companion frontend PR for the tt-metal uplift in tenstorrent/tt-mlir#9244.

The uplift fixes these cases, so their `strict` xfail marks now surface as
failures via `XPASS(strict)`. Removing the marks.

### Un-xfailed

| test | params |
|---|---|
| `test_reduce_sum` | 12 |
| `test_reduce_mean` | 6 |
| `test_divide` | 1 (`shape1`) |

### Why these are XPASS, not new breakage

Against the uplift, `passed` is unchanged at 697 while `xfailed` drops
106 -> 96 and `failed` rises 6 -> 16. Had these genuinely regressed, `passed`
would have dropped instead. So exactly these params moved xfail -> unexpected
pass.

`test_reduce_max` keeps all 12 of its marks. Those 6-per-job failures are
present on the pre-uplift baseline too (runs on 2026-08-24 and 2026-08-26
09:25), so they are unrelated to the uplift.

### Merge order -- please do not merge early

This depends on tt-forge-onnx picking up a tt-mlir that contains
tenstorrent/tt-mlir#9244. **Merged before that, these tests fail for real
rather than xfailing, and main goes red.**

Until the tt-mlir uplift lands here the existing marks are still correct, so
this PR is raised to be *ready* (per the uplift process bar) rather than to
merge immediately. Verified against the uplift via `mlir_override` on the
`on-pr` workflow.